### PR TITLE
Add missing prettier dependency & fix linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: '' # See documentation for possible values
+  - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: '' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     # group all non-major dev dep updates together into a single PR
     groups:
       development-dependencies:

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "24.9.2",
         "cross-env": "10.1.0",
         "del-cli": "7.0.0",
+        "eslint-config-prettier": "10.1.8",
         "husky": "9.1.7",
         "jest": "30.2.0",
         "lint-staged": "16.2.6",
@@ -4906,8 +4907,6 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "memcached-mock": "0.1.0",
         "npm-run-all": "4.1.5",
         "pkgroll": "2.20.1",
+        "prettier": "^3.0.0",
         "ts-jest": "29.4.5",
         "ts-node": "10.9.2",
         "tsx": "4.20.6",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "memcached-mock": "0.1.0",
     "npm-run-all": "4.1.5",
     "pkgroll": "2.20.1",
+    "prettier": "^3.0.0",
     "ts-jest": "29.4.5",
     "ts-node": "10.9.2",
     "tsx": "4.20.6",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/node": "24.9.2",
     "cross-env": "10.1.0",
     "del-cli": "7.0.0",
+    "eslint-config-prettier": "10.1.8",
     "husky": "9.1.7",
     "jest": "30.2.0",
     "lint-staged": "16.2.6",


### PR DESCRIPTION
I turned on dependabot and everything started failing the lint check. I'm not sure how we ended up in this state, but lint was failing in CI because it was missing prettier, and then when I added it, it started failing because of formatting complaints in dependabot.yml

This will hopefully fix all of that.